### PR TITLE
Add DiscordChannel parameter as !remind message target channel

### DIFF
--- a/src/Commands/ReminderCommandsModule.cs
+++ b/src/Commands/ReminderCommandsModule.cs
@@ -101,18 +101,30 @@ namespace discordbot.Commands
             }
 
             DiscordChannel targetChannel = null;
-            if (toChannel == "here")
+
+            try
             {
-                targetChannel = ctx.Channel;
+                if (toChannel == "here")
+                {
+                    targetChannel = ctx.Channel;
+                }
+
+                else
+                {
+                    string getChannelId = string.Join("", toChannel.Where(char.IsDigit));
+                    ulong channelId = Convert.ToUInt64(getChannelId);
+
+                    targetChannel = await Bot.Client.GetChannelAsync(channelId);
+                }
             }
 
-            else
+            catch
             {
-                string getChannelId = string.Join("", toChannel.Where(char.IsDigit));
-                ulong channelId = Convert.ToUInt64(getChannelId);
+                string toSend = $"{Formatter.Bold("[ERROR]")} You cannot mention a channel that does not exist or that you do not have access to. Make sure you are using the command like this: !remind humas 11:30 <#838652424436449290> Koordinasi proposal dengan KFC.";
+                await ctx.RespondAsync(toSend).ConfigureAwait(false);
 
-                targetChannel = await Bot.Client.GetChannelAsync(channelId);
-            }
+                return;
+            }            
 
             if (timeSpan.Contains("/"))
             {


### PR DESCRIPTION
# Summary
This PR adds an option for users to specify a channel to which the `!remind` message must be sent. If a message is not needed to be sent to another channel, type `here` on the channel parameter.